### PR TITLE
fix: update deployment base path

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -2,7 +2,10 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
-const base = process.env.VITE_BASE_PATH || '/method-mosaic/'
+// Ensure the built assets are served from the correct subpath when deploying
+// to GitHub Pages. The repository was renamed to "Method-Mosaic", so update
+// the default base path to match the new casing.
+const base = process.env.VITE_BASE_PATH || '/Method-Mosaic/'
 
 export default defineConfig({
   base,


### PR DESCRIPTION
## Summary
- use `Method-Mosaic` as Vite base path for GitHub Pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d1d8640288329a2a2f8fa84ddbd55