### PR TITLE
feat: add asset removal and review modal

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Settings2, LayoutGrid, GripVertical, Download, FileDown, Upload, ImagePlus, RotateCcw, Trash2, Image as ImageIcon, ChevronDown, ChevronRight, HelpCircle } from "lucide-react";
+import { Settings2, LayoutGrid, GripVertical, Download, FileDown, Upload, ImagePlus, RotateCcw, Trash2, Image as ImageIcon, ChevronDown, ChevronRight, HelpCircle, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -34,6 +34,7 @@ export default function MethodMosaic() {
   const [images, setImages] = useState(/** @type {BoardImage[]} */([]));
   const [assets, setAssets] = useState([]);
   const [assetPanelOpen, setAssetPanelOpen] = useState(false);
+  const [reviewOpen, setReviewOpen] = useState(false);
   const originalOrderRef = useRef([]);
   const [draggingId, setDraggingId] = useState(null);
   const [dragOverId, setDragOverId] = useState(null);
@@ -231,6 +232,18 @@ export default function MethodMosaic() {
 
   const clearAll = () => { setImages([]); originalOrderRef.current = []; };
   const removeImage = (id) => { setImages((prev) => prev.filter((i) => i.id !== id)); originalOrderRef.current = originalOrderRef.current.filter((x) => x !== id); };
+  const removeAsset = (id) => {
+    setAssets((prev) => prev.filter((a) => a.id !== id));
+    setImages((prev) => prev.filter((i) => i.assetId !== id));
+    originalOrderRef.current = originalOrderRef.current.filter((x) => {
+      const img = images.find((i) => i.id === x);
+      return img && img.assetId !== id;
+    });
+  };
+  const clearAssets = () => {
+    setAssets([]);
+    clearAll();
+  };
 
   const onLogoFiles = async (files) => {
     if (!files?.[0]) return; const file = files[0]; const src = await readFileAsDataURL(file); setLogoSrc(src);
@@ -414,6 +427,9 @@ export default function MethodMosaic() {
         <Button variant="outline" size="sm" onClick={() => setAssetPanelOpen((prev) => !prev)}>
           <LayoutGrid className="h-4 w-4 mr-1" />Assets
         </Button>
+        <Button variant="outline" size="sm" onClick={() => setReviewOpen(true)}>
+          Leave Review
+        </Button>
         <Button variant="ghost" size="sm" onClick={resetOrder}>
           <RotateCcw className="h-4 w-4 mr-1" />Reset Order
         </Button>
@@ -595,10 +611,31 @@ export default function MethodMosaic() {
                 </div>
               </CardContent>
             </Card>
-          <Review />
         </div>
       </div>
-      <AssetPanel assets={assets} open={assetPanelOpen} onClose={() => setAssetPanelOpen(false)} />
+      <AssetPanel
+        assets={assets}
+        open={assetPanelOpen}
+        onClose={() => setAssetPanelOpen(false)}
+        onRemoveAsset={removeAsset}
+        onClearAssets={clearAssets}
+      />
+      {reviewOpen && (
+        <div className="fixed inset-0 z-50 grid place-items-center bg-black/60 p-4">
+          <div className="relative bg-white dark:bg-neutral-900 rounded-2xl shadow-xl max-w-md w-full p-6">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="absolute top-2 right-2"
+              onClick={() => setReviewOpen(false)}
+              aria-label="Close review"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+            <Review />
+          </div>
+        </div>
+      )}
       {cropOpenId && (
         <div className="fixed inset-0 z-50 grid place-items-center bg-black/60 p-4" onMouseUp={onPreviewMouseUpLeave} onMouseLeave={onPreviewMouseUpLeave}>
           <div className="w-full max-w-[720px] bg-white dark:bg-neutral-900 rounded-2xl shadow-xl border border-neutral-200 dark:border-neutral-700 p-6">

--- a/src/components/AssetPanel.jsx
+++ b/src/components/AssetPanel.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { ChevronRight } from "lucide-react";
+import { ChevronRight, Trash2 } from "lucide-react";
 
 const cx = (...cls) => cls.filter(Boolean).join(" ");
 
@@ -9,7 +9,7 @@ const cx = (...cls) => cls.filter(Boolean).join(" ");
  * @typedef {{id:string, src:string, name:string}} Asset
  */
 
-export default function AssetPanel({ assets, open, onClose }) {
+export default function AssetPanel({ assets, open, onClose, onRemoveAsset, onClearAssets }) {
   const [query, setQuery] = useState("");
   const filtered = assets.filter((a) => a.name.toLowerCase().includes(query.toLowerCase()));
 
@@ -21,11 +21,21 @@ export default function AssetPanel({ assets, open, onClose }) {
       )}
     >
       <div className="p-4 border-b border-neutral-200 dark:border-neutral-700">
-        <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center justify-between mb-3 gap-2">
           <h2 className="font-semibold">Assets</h2>
-          <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close assets">
-            <ChevronRight className="h-4 w-4" />
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onClearAssets}
+              aria-label="Remove all assets"
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+            <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close assets">
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
         </div>
         <Input
           placeholder="Search..."
@@ -34,19 +44,32 @@ export default function AssetPanel({ assets, open, onClose }) {
           className="h-8 text-sm"
         />
       </div>
-      <div className="p-4 grid grid-cols-2 gap-2 overflow-y-auto" style={{ maxHeight: "calc(100% - 88px)" }}>
+      <div
+        className="p-4 grid grid-cols-2 gap-2 overflow-y-auto"
+        style={{ maxHeight: "calc(100% - 88px)" }}
+      >
         {filtered.map((asset) => (
-          <img
-            key={asset.id}
-            src={asset.src}
-            alt={asset.name}
-            className="w-full h-24 object-cover rounded-md cursor-grab"
-            draggable
-            onDragStart={(e) => {
-              e.dataTransfer.setData("application/x-asset-id", asset.id);
-              e.dataTransfer.effectAllowed = "copy";
-            }}
-          />
+          <div key={asset.id} className="relative group">
+            <img
+              src={asset.src}
+              alt={asset.name}
+              className="w-full h-24 object-cover rounded-md cursor-grab"
+              draggable
+              onDragStart={(e) => {
+                e.dataTransfer.setData("application/x-asset-id", asset.id);
+                e.dataTransfer.effectAllowed = "copy";
+              }}
+            />
+            <Button
+              variant="secondary"
+              size="icon"
+              className="absolute top-1 right-1 h-6 w-6 opacity-0 group-hover:opacity-100"
+              onClick={() => onRemoveAsset(asset.id)}
+              aria-label="Remove asset"
+            >
+              <Trash2 className="h-3 w-3" />
+            </Button>
+          </div>
         ))}
         {filtered.length === 0 && (
           <p className="col-span-2 text-sm text-neutral-500">No assets</p>


### PR DESCRIPTION
## Summary
- allow clearing all assets or individual ones in the asset drawer
- move review form to modal opened from toolbar

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d2b8f811c83298f1a9ddc3c44ab63