### PR TITLE
style: render header logo in black

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -424,7 +424,7 @@ export default function MethodMosaic() {
         <div className="flex items-center gap-2">
           <svg
             viewBox="0 0 40 40"
-            className="h-6 w-6 text-indigo-500"
+            className="h-6 w-6 text-black"
             fill="currentColor"
             aria-hidden="true"
           >


### PR DESCRIPTION
## Summary
- render header logo in black for a neutral appearance

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d4a5372e8832993ee7d4c87912b09