### PR TITLE
Set range sliders to black

### DIFF
--- a/src/components/ui/slider.jsx
+++ b/src/components/ui/slider.jsx
@@ -5,6 +5,6 @@ export const Slider = ({ min=0, max=100, step=1, value=[0], onValueChange=()=>{}
   return (
     <input type="range" min={min} max={max} step={step} value={v}
       onChange={(e)=>onValueChange([Number(e.target.value)])}
-      className={['w-full', className].join(' ')} />
+      className={['w-full accent-black', className].join(' ')} />
   )
 }


### PR DESCRIPTION
## Summary
- use `accent-black` on range inputs so sliders render in black instead of blue

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d4e81b2c48329a6c4e2217f2e1c38