### PR TITLE
fix: enforce light theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light" />
     <title>Method Mosaic</title>
     <link rel="icon" type="image/svg+xml" href="./logo.svg" />
   </head>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,7 @@
 
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
   theme: { extend: {} },
   plugins: [],


### PR DESCRIPTION
## Summary
- ensure Tailwind only applies dark styles via explicit class
- declare light color scheme for browser controls

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d52e3a07083299d668cc5c723d22d