### PR TITLE
feat: add .mlmboard save and load

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "method-mosaic",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "method-mosaic",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "dependencies": {
         "html-to-image": "^1.11.11",
         "jspdf": "^2.5.1",
         "lucide-react": "^0.479.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "fflate": "^0.8.2"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "method-mosaic",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -14,7 +14,8 @@
     "jspdf": "^2.5.1",
     "lucide-react": "^0.479.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "fflate": "^0.8.2"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.1",


### PR DESCRIPTION
## Summary
- add fflate-based project save/load (.mlmboard) bundling meta and assets
- store schema version and guard against newer formats
- expose Save/Load controls in settings and bump version to 1.1.0

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689d5cff226883298225e59c467f5f5e