### PR TITLE
Remove unused ChevronLeft import from AssetPanel

### DIFF
--- a/src/components/AssetPanel.jsx
+++ b/src/components/AssetPanel.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { ChevronLeft, LayoutGrid, Trash2 } from "lucide-react";
+import { LayoutGrid, Trash2 } from "lucide-react";
 
 const cx = (...cls) => cls.filter(Boolean).join(" ");
 


### PR DESCRIPTION
## Summary
- remove unused ChevronLeft import from AssetPanel component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a522da19fc8329ac1a5ad04e1d2409