### PR TITLE
fix: make reset settings button icon-only

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -657,7 +657,14 @@ export default function MethodMosaic() {
         <div className="pb-2">
           <div className="flex items-center justify-between">
             <h2 className="text-xl font-semibold">Moodboard Settings</h2>
-            <Button variant="ghost" size="sm" onClick={resetSettings}>Reset</Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={resetSettings}
+              aria-label="Reset settings"
+            >
+              <RotateCcw className="h-4 w-4" />
+            </Button>
           </div>
         </div>
         <div className="space-y-6">


### PR DESCRIPTION
## Summary
- use RotateCcw icon-only button for resetting settings

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5377429ec832987542edb99814272